### PR TITLE
Make image paths in diff.html work when diff.html is made outside the working directory

### DIFF
--- a/idiff.go
+++ b/idiff.go
@@ -88,11 +88,10 @@ func main() {
 	left := filepath.Clean(os.Args[1])
 	right := filepath.Clean(os.Args[2])
 	diff := "diff.html"
-        diffbase := filepath.Base(diff)
+	diffbase := filepath.Base(diff)
 	if len(os.Args) > 3 {
 		diff = os.Args[3]
 	}
-	fmt.Println("diffbase: ", diff)
 
 	wg := &sync.WaitGroup{}
 	diffs := make(DiffSlice, 0)

--- a/idiff.go
+++ b/idiff.go
@@ -91,6 +91,7 @@ func main() {
 	if len(os.Args) > 3 {
 		diff = os.Args[3]
 	}
+	fmt.Println("diffbase: ", diff)
 
 	wg := &sync.WaitGroup{}
 	diffs := make(DiffSlice, 0)
@@ -131,8 +132,10 @@ func main() {
 			}
 
 			if diff := DiffImages(li, ri); diff > 0 {
+				left, _ := filepath.Rel(diffbase, path)
+				right, _ := filepath.Rel(diffbase, rpath)
 				mutex.Lock()
-				diffs = append(diffs, Diff{path, rpath, diff})
+				diffs = append(diffs, Diff{left, right, diff})
 				mutex.Unlock()
 			}
 		}()

--- a/idiff.go
+++ b/idiff.go
@@ -88,6 +88,7 @@ func main() {
 	left := filepath.Clean(os.Args[1])
 	right := filepath.Clean(os.Args[2])
 	diff := "diff.html"
+        diffbase := filepath.Base(diff)
 	if len(os.Args) > 3 {
 		diff = os.Args[3]
 	}


### PR DESCRIPTION
I made the paths to the images be relative to the base of diff.html rather than absolute so that you could still relocate a common ancestor of good/, bad/ and diff.html by say 'mv' or zipping and emailing. 
